### PR TITLE
Support of country and its subdivision and script

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,15 @@ function withAndroidLocalizedName(config) {
                         resources.push({ string: { $: { name: key }, _: strings[key] } });
                 }
                 if (resources.length) {
-                    await fs.promises.mkdir(path.resolve(resPath, `values-${locale}`), { recursive: true });
+                    let finalLocale = locale;
+                    if (finalLocale.includes("-")) {
+                        finalLocale = `b+${finalLocale.replaceAll("-", "+")}`;
+                    }
+                    await fs.promises.mkdir(path.resolve(resPath, `values-${finalLocale}`), {
+                        recursive: true,
+                    });
                     await fs.promises.writeFile(
-                        path.resolve(resPath, `values-${locale}`, 'strings.xml'),
+                        path.resolve(resPath, `values-${finalLocale}`, 'strings.xml'),
                         builder.buildObject({ resources })
                     );
                 }


### PR DESCRIPTION
In Android, we can use ISO 639 (language), ISO 3166 (country and its subdivision) and ISO 15924 (script) for localization, e.g., `en-US`, `zh-Hans`, `sr-Latn-SR`.

According to https://developer.android.com/guide/topics/resources/localization#creating-alternatives and https://developer.android.com/training/basics/supporting-devices/languages#CreateDirs, we need to use BCP 47 format `values-b+<LANGUAGE>+<SCRIPT>+<COUNTRY_OR_ITS_SUBDIVISION>` to create multi-language locale directories.

In this patch, we will keep the original format for locales using only languages for compatibility, and use the new format for locales including countries and their divisions and scripts.